### PR TITLE
Fix time comparison in debug build

### DIFF
--- a/main.c
+++ b/main.c
@@ -137,7 +137,9 @@ int main() {
             picoemp_enable_pwm();
         }
 
-        if(timeout_active && (get_absolute_time() > timeout_time) && armed) {
+        if(timeout_active && 
+            (to_us_since_boot(get_absolute_time()) > to_us_since_boot(timeout_time)) 
+            && armed) {
             disarm();
         }
     }


### PR DESCRIPTION
There is weird definition of `absolute_time_t` type in Rpi Pico SDK.

In case of Release build, it translates to `uint64_t`, but under Debug build it becomes strangely a struct with `uint64_t` field - https://raspberrypi.github.io/pico-sdk-doxygen/types_8h_source.html (line 30). 

So the way that works for both builds is using extra function to extract the time for comparison.